### PR TITLE
Added correct limiters for ini and rainmeter files

### DIFF
--- a/src/limiters.ts
+++ b/src/limiters.ts
@@ -61,6 +61,8 @@ export const getLanguageLimiters = (lang?: string): ILimiters => {
     case 'clojure':
     case 'lisp':
     case 'scheme':
+    case 'ini':
+    case 'rainmeter':
       return wrapLimiters(';', ';');
 
     case 'elm':


### PR DESCRIPTION
The comment limiters in ini files are semicolons: https://en.wikipedia.org/wiki/INI_file
Rainmeter is a windows desktop customizer, uses the ini format as well. I use it regularly, and I needed this functionality. 
I just changed this on the github website without cloning, it was quicker then opening an issue, I hope It should be changed only here.
Thanks for this genial plugin!