### PR TITLE
Added compatibility for Home Assistant plugin

### DIFF
--- a/src/limiters.ts
+++ b/src/limiters.ts
@@ -48,6 +48,7 @@ export const getLanguageLimiters = (lang?: string): ILimiters => {
     case 'shellscript':
     case 'yaml':
     case 'yml':
+    case 'home-assistant':
       return wrapLimiters('#', '#');
 
     case 'html':


### PR DESCRIPTION
By default, vscode generates `/* ... */` comments for files edited with Home Assistant extension.
This (tested) change adds support for the extension to enable `# ... #` comment generation.

_Home Assistant_ VSCode Extension page: https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant