### PR TITLE
Solved indent issue and added fixLength argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,11 @@
           "maxLength": 1,
           "default": "-",
           "description": "Set symbol for solid line filling."
+        },
+        "comment-divider.fixLength": {
+          "type": "boolean",
+          "default": false,
+          "description": "Set whether the lines will be fixed sized or not. When enabled, a 76-length header will be inserted in a 4-space indented line with an 80-length line configuration to fix the current line length to 80."
         }
       }
     }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,11 +1,6 @@
-import { commands, TextEditorEdit, TextLine, window } from 'vscode';
+import { commands, TextEditorEdit, window } from 'vscode';
 
-import {
-  renderHeader,
-  renderLine,
-  wrapWithMargins,
-  wrapWithLinebreaker
-} from './renders';
+import {wrapWithMargins, wrapWithLineBreaker, renderComment} from './renders';
 import { checkEmptyLine } from './errors';
 import { Action } from './types';
 
@@ -14,7 +9,7 @@ import { Action } from './types';
 export const insertMainHeader: Action = (line, lang) => {
   checkEmptyLine(line);
 
-  const rendered = renderHeader('mainHeader', line.text, lang);
+  const rendered = renderComment('mainHeader', line.text, lang);
   const content = wrapWithMargins(rendered, line);
 
   window.activeTextEditor
@@ -31,7 +26,7 @@ export const insertMainHeader: Action = (line, lang) => {
 export const insertSubHeader: Action = (line, lang) => {
   checkEmptyLine(line);
 
-  const rendered = renderHeader('subheader', line.text, lang);
+  const rendered = renderComment('subheader', line.text, lang);
   const content = wrapWithMargins(rendered, line);
 
   window.activeTextEditor
@@ -46,8 +41,8 @@ export const insertSubHeader: Action = (line, lang) => {
 ///
 
 export const insertSolidLine: Action = (line, lang) => {
-  const rendered = renderLine(lang);
-  const content = wrapWithLinebreaker(rendered);
+  const rendered = renderComment('line', line.text, lang);
+  const content = wrapWithLineBreaker(rendered);
 
   window.activeTextEditor
     .edit((textEditorEdit: TextEditorEdit) => {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -129,34 +129,42 @@ const composeInjectors = (...injectors) => (charList: CharList) =>
 
 /* ------------------------------ Line Builders ----------------------------- */
 
-export const buildSolidLine = (config: IConfig): string => {
+export const buildSolidLine = (config: IConfig, indent: string = ''): string => {
   const injectLimiters = withLimiters(config.limiters.left, config.limiters.right);
 
   const blankCharList = buildBlankCharList(config.lineLen, config.sym);
   const computedCharList = composeInjectors(injectLimiters)(blankCharList);
 
-  return charListToString(computedCharList);
+  return indent + charListToString(computedCharList);
 };
 
 ///
 
-export const buildWordsLine = (config: IConfig, transformedWords: string): string => {
+export const buildWordsLine = (
+  config: IConfig,
+  transformedWords: string,
+  indent: string = ''
+): string => {
   const injectLimiters = withLimiters(config.limiters.left, config.limiters.right);
   const injectWords = withWords(config.align, transformedWords);
 
   const blankCharList = buildBlankCharList(config.lineLen, config.sym);
   const computedCharList = composeInjectors(injectLimiters, injectWords)(blankCharList);
 
-  return charListToString(computedCharList);
+  return indent + charListToString(computedCharList);
 };
 
 /* ----------------------------- Block Builders ----------------------------- */
 
-export const buildBlock = (config: IConfig, transformedWords: string): string => {
+export const buildBlock = (
+  config: IConfig,
+  transformedWords: string,
+  indent: string = ''
+): string => {
   const textConfig: IConfig = { ...config, sym: GAP_SYM };
-  const topLine = buildSolidLine(config);
-  const textLine = buildWordsLine(textConfig, transformedWords);
-  const bottomLine = buildSolidLine(config);
+  const topLine = buildSolidLine(config, indent);
+  const textLine = buildWordsLine(textConfig, transformedWords, indent);
+  const bottomLine = buildSolidLine(config, indent);
 
   return topLine + NEW_LINE_SYM + textLine + NEW_LINE_SYM + bottomLine;
 };

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,6 +26,7 @@ const getEditorState = (editor: TextEditor) => {
 const generateCommand = (action: Action) => () => {
   try {
     const editor: TextEditor = window.activeTextEditor;
+    
     if (!editor) return;
 
     const { lang, line } = getEditorState(editor);

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,8 +14,9 @@ const getPreset = (type: PresetId): IPreset => {
   const height = section.get<Height>(`${type}Height`);
   const align = section.get<Align>(`${type}Align`);
   const transform = section.get<Transform>(`${type}Transform`);
+  const fixLen = section.get<boolean>('fixLength');
 
-  return { lineLen, sym, height, align, transform };
+  return { lineLen, sym, height, align, transform, fixLen };
 };
 
 ///

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,7 @@
 import { window, Selection, TextLine } from 'vscode';
 
 import { EXT_NAME } from './constants';
-import { ILimiters } from './types';
+import { IConfig, ILimiters } from './types';
 
 ///
 
@@ -18,6 +18,17 @@ export const ERRORS = {
 
 const showErrorMsg = (msg: string) =>
   window.showInformationMessage(`${EXT_NAME}: ${msg}`);
+
+const getMaxAllowedLen = (config: IConfig, indentLen: number = 0) => {
+  const limitersLen = config.limiters.left.length + config.limiters.right.length;
+  const gapsCount = 4;
+  const minFillerCount = 2;
+  return config.lineLen
+    - limitersLen
+    - gapsCount
+    - minFillerCount
+    - (config.fixLen ? indentLen : 0);
+};
 
 /* -------------------------------- Checkers -------------------------------- */
 
@@ -40,11 +51,8 @@ export const checkCommentChars = (text: string, limiters: ILimiters) => {
 
 ///
 
-export const checkLongText = (text: string, lineLen: number, limiters: ILimiters) => {
-  const limitersLen = limiters.left.length + limiters.right.length;
-  const gapsCount = 4;
-  const minFillerCount = 2;
-  const maxAllowedLen = lineLen - (limitersLen + gapsCount + minFillerCount);
+export const checkLongText = (text: string, config: IConfig, indentLen: number) => {
+  const maxAllowedLen = getMaxAllowedLen(config, indentLen);
   if (text.length > maxAllowedLen) throw new Error('LONG_TEXT');
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface IPreset {
   height: Height;
   align: Align;
   transform: Transform;
+  fixLen: boolean;
 }
 
 export interface IConfig extends IPreset {


### PR DESCRIPTION
# Indent Issue
As can be seen in [this issue](#12), when someone adds a comment divider in an indented line, the indent is removed (and this made me so uncomfortable). Example:
```ts
// normally, this line:
what a nice comment
// turns into that comment when a divider inserted:
/* --------------------------- what a nice comment -------------------------- */

// but when there is an indent at the start, this line:
    what a nice indented comment
// turns into that (indent is gone):
/* ---------------------- what a nice indented comment ---------------------- */
```
So I made some changes and solved this issue:
```ts
/* --------------------------- what a nice comment -------------------------- */
    /* ---------------------- what a nice indented comment ---------------------- */
```

But now, a new question came to my mind. Which way should indented lines be commented?
```ts

// first way
/* --------------------------------- indent0 -------------------------------- */

    /* --------------------------------- indent1 -------------------------------- */
    
        /* --------------------------------- indent2 -------------------------------- */

// second way
/* --------------------------------- indent0 -------------------------------- */

    /* ------------------------------- indent1 ------------------------------ */
    
        /* ----------------------------- indent2 ---------------------------- */
```

So I implemented a new argument/setting: `comment-divider.fixLength`

# Fix Length
`comment-divider.fixLength` is a `boolean` argument and `false` in default.  When enabled, the line length will be fixed(the second way).

## Notes
- When a comment divider is inserted in an indented line, tabs will be converted to spaces.
- I might a little messed up with adding indent to arguments because there are plenty of inherited-function-layers.
- There was a function to add margins (empty line) when up or bottom lines are not empty named `wrapWithMargins()` but this function was called in upper levels of inherited-function-layers (so it needs some structure change in the project to make margins indented). But I didn't want to mess more with the project structure and didn't add indent to that margins.